### PR TITLE
README clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ KISS and BetaFlight GUI on ESP8266
 ### Requirements
 - ESP8266 module with at least 4MB flash. [This module](https://www.wemos.cc/product/d1-mini-pro.html) weights 2.5g and is ready to go
 - Recent version of [Arduino IDE](https://www.arduino.cc/en/Main/Software)
-- Latest [Arduino ESP8266 filesystem uploader](https://github.com/esp8266/arduino-esp8266fs-plugin) plugin installed
-- Git version of [ESP8266 Arduino](https://github.com/esp8266/Arduino#using-git-version)
-- Git version of [ESPAsyncTCP](https://github.com/me-no-dev/ESPAsyncTCP)
-- Git version of [ESPAsyncWebServer](https://github.com/me-no-dev/ESPAsyncWebServer)
+- Latest [Arduino ESP8266 filesystem uploader](https://github.com/esp8266/arduino-esp8266fs-plugin) plugin installed - put inside `Documents/Arduino/tools`
+- Git version of [ESP8266 Arduino](https://github.com/esp8266/Arduino#using-git-version) - put inside `<Arduino installation directory>`, as per the instructions
+- Git version of [ESPAsyncTCP](https://github.com/me-no-dev/ESPAsyncTCP) - put inside `<Arduino installation directory>/hardware/esp8266com/esp8266/libraries`
+- Git version of [ESPAsyncWebServer](https://github.com/me-no-dev/ESPAsyncWebServer) - put inside the same root directory as above
 
 ### Compiling and upload
 - Fullfill all requirements above

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ KISS and BetaFlight GUI on ESP8266
 
 ### Compiling and upload
 - Fullfill all requirements above
-- If on Windows, reset permissions for the directory `<Arduino installation directory>\hardware\esp8266com\esp8266\tools\esptool` since they will be corrupt and the file not able to be opened (Properties, Security, Edit, say Yes to reordering, give your user at least read access)
+- If on Windows, if you get any errors during the below operations, ensure there is no permissions issue by resetting permissions for the directory and all subdirectories in `<Arduino installation directory>\hardware\esp8266com` since they might be corrupt and the files not able to be opened (Properties, Security, Edit, say Yes to reordering, give your user at least read access)
 - Clone or download this repository to your computer
 - Sketch ino and folder name MUST match
 - Open the ino sketch with Arduino IDE

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ KISS and BetaFlight GUI on ESP8266
 
 ### Compiling and upload
 - Fullfill all requirements above
+- If on Windows, reset permissions for the directory `<Arduino installation directory>\hardware\esp8266com\esp8266\tools\esptool` since they will be corrupt and the file not able to be opened (Properties, Security, Edit, say Yes to reordering, give your user at least read access)
 - Clone or download this repository to your computer
 - Sketch ino and folder name MUST match
 - Open the ino sketch with Arduino IDE

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ KISS and BetaFlight GUI on ESP8266
 ### Requirements
 - ESP8266 module with at least 4MB flash. [This module](https://www.wemos.cc/product/d1-mini-pro.html) weights 2.5g and is ready to go
 - Recent version of [Arduino IDE](https://www.arduino.cc/en/Main/Software)
-- Latest [Arduino ESP8266 filesystem uploader](https://github.com/esp8266/arduino-esp8266fs-plugin) plugin installed - put inside `Documents/Arduino/tools`
+- Latest [Arduino ESP8266 filesystem uploader](https://github.com/esp8266/arduino-esp8266fs-plugin) plugin installed - put inside `<Arduino installation directory>/tools`
 - Git version of [ESP8266 Arduino](https://github.com/esp8266/Arduino#using-git-version) - put inside `<Arduino installation directory>`, as per the instructions
 - Git version of [ESPAsyncTCP](https://github.com/me-no-dev/ESPAsyncTCP) - put inside `<Arduino installation directory>/hardware/esp8266com/esp8266/libraries`
 - Git version of [ESPAsyncWebServer](https://github.com/me-no-dev/ESPAsyncWebServer) - put inside the same root directory as above


### PR DESCRIPTION
It took me a while to figure out where the tools/libraries should go (it wasn't working when I put them into my Documents/Arduino folder), so this should help other people use the correct directories.

Additionally, there's a permissions issue since the esptool Python script seems to generate invalid folder and file permissions when it downloads the `esptools.exe` file on Windows.